### PR TITLE
CF-371: add handling where content-type is set via setHeader()

### DIFF
--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -90,10 +90,19 @@ public class Xml2JsonFilter implements Filter {
 
         @Override
         public void setHeader(String name, String value) {
-            if ( StringUtils.isNotBlank(name) && name.equalsIgnoreCase(CONTENT_TYPE_HEADER) ) {
+            if ( CONTENT_TYPE_HEADER.equalsIgnoreCase(name) ) {
                 super.setHeader(name, swizzleContentType(value));
             } else {
                 super.setHeader(name, value);
+            }
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            if ( CONTENT_TYPE_HEADER.equalsIgnoreCase(name) ) {
+                super.addHeader(name, swizzleContentType(value));
+            } else {
+                super.addHeader(name, value);
             }
         }
 


### PR DESCRIPTION
I neglected to cover some scenarios where the Content-Type is set via calls to setHeader() method. This PR handles that.