### PR TITLE
CF-478 Move Repose translation filter to feeds-catalog

### DIFF
--- a/filters/filter-utils/src/main/java/com/rackspace/feeds/filter/StringResponseWrapper.java
+++ b/filters/filter-utils/src/main/java/com/rackspace/feeds/filter/StringResponseWrapper.java
@@ -1,0 +1,52 @@
+package com.rackspace.feeds.filter;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+/**
+ * Wrapper for HttpServletResponse that collect the response output
+ * that can be retrieved as string
+ */
+public class StringResponseWrapper extends HttpServletResponseWrapper {
+    private PrintWriter writer = null;
+    private ByteArrayOutputStream stream;
+    private ServletOutputStreamWrapper servletOutputStream;
+
+    /**
+     * Create a wrapper for servlet response
+     * @param response
+     */
+    public StringResponseWrapper(HttpServletResponse response){
+        super(response);
+        this.stream = new ByteArrayOutputStream();
+        this.servletOutputStream = new ServletOutputStreamWrapper(stream);
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+        if ( writer != null ) {
+            return writer;
+        }
+        writer = new PrintWriter(servletOutputStream);
+        return writer;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() {
+        if ( writer != null ) {
+            throw new IllegalStateException("getWriter() has already been called");
+        }
+        return servletOutputStream;
+    }
+
+    /**
+     * Return string of the response content
+     * @return
+     */
+    public String getResponseString() {
+        return this.stream.toString();
+    }
+}

--- a/filters/filter-utils/src/main/java/com/rackspace/feeds/filter/StringResponseWrapper.java
+++ b/filters/filter-utils/src/main/java/com/rackspace/feeds/filter/StringResponseWrapper.java
@@ -19,26 +19,20 @@ public class StringResponseWrapper extends HttpServletResponseWrapper {
      * Create a wrapper for servlet response
      * @param response
      */
-    public StringResponseWrapper(HttpServletResponse response){
+    public StringResponseWrapper(HttpServletResponse response) {
         super(response);
-        this.stream = new ByteArrayOutputStream();
-        this.servletOutputStream = new ServletOutputStreamWrapper(stream);
+        stream = new ByteArrayOutputStream();
+        servletOutputStream = new ServletOutputStreamWrapper(stream);
+        writer = new PrintWriter(servletOutputStream);
     }
 
     @Override
     public PrintWriter getWriter() {
-        if ( writer != null ) {
-            return writer;
-        }
-        writer = new PrintWriter(servletOutputStream);
-        return writer;
+       return writer;
     }
 
     @Override
     public ServletOutputStream getOutputStream() {
-        if ( writer != null ) {
-            throw new IllegalStateException("getWriter() has already been called");
-        }
         return servletOutputStream;
     }
 
@@ -47,6 +41,6 @@ public class StringResponseWrapper extends HttpServletResponseWrapper {
      * @return
      */
     public String getResponseString() {
-        return this.stream.toString();
+        return stream.toString();
     }
 }

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonExtendedFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonExtendedFilter.java
@@ -1,0 +1,86 @@
+package com.rackspace.feeds.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.util.Collections;
+
+/**
+ * This filter extends the Xml2JsonFilter and modify the behavior to not use piped async call,
+ * and to set the contentLength of the transformed response.
+ *
+ * It requires a Filter input parameter called 'xsltFile' which is the full path to the XSLT file to perform the
+ * transformation.
+ */
+public class Xml2JsonExtendedFilter extends Xml2JsonFilter {
+    private static Logger LOG = LoggerFactory.getLogger(Xml2JsonExtendedFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest servletRequest,
+                         ServletResponse servletResponse,
+                         final FilterChain chain)
+            throws java.io.IOException, ServletException {
+
+        LOG.debug( "Xml2JsonExtendedFilter doFilter()" );
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+
+        if( jsonPreferred(httpServletRequest) ) {
+
+            //create wrapper response with output stream to collect transformed content
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            ServletOutputStreamWrapper outputStreamWrapper = new ServletOutputStreamWrapper(stream);
+            OutputStreamResponseWrapper wrappedResponse =
+                    new OutputStreamResponseWrapper(httpServletResponse, outputStreamWrapper);
+
+            // apply filter further down the chain on wrapped response
+            chain.doFilter(httpServletRequest, wrappedResponse);
+
+            // obtain response content
+            String originalResponseContent = stream.toString();
+            LOG.debug("Original response content length = " + originalResponseContent.length());
+
+            if (StringUtils.isNotEmpty(originalResponseContent)) {
+
+                try {
+                    OutputStream outputStream = new ByteArrayOutputStream();
+
+                    // transform response content with the xml to json xslt
+                    transformer.doTransform(Collections.EMPTY_MAP,
+                            new StreamSource(new StringReader(originalResponseContent)),
+                            new StreamResult(outputStream));
+
+                    String jsonResponseContent = outputStream.toString();
+                    LOG.debug("New response content length = " + jsonResponseContent.length());
+
+                    // set new json response wrapper with the transformed json content
+                    JsonResponseBodyWrapper jsonBodyWrapper = new JsonResponseBodyWrapper( httpServletResponse );
+                    jsonBodyWrapper.setContentLength(jsonResponseContent.length());
+                    jsonBodyWrapper.setContentType(RAX_SVC_JSON_MEDIA_TYPE);
+                    jsonBodyWrapper.getWriter().write(jsonResponseContent);
+                }
+                catch (Exception e) {
+                    LOG.error("Error transforming xml: " + e.getMessage());
+                }
+                finally {
+                    httpServletResponse.getWriter().close();
+                }
+            }
+        }
+        else {
+            chain.doFilter( servletRequest, servletResponse );
+        }
+    }
+}

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -31,20 +31,19 @@ public class Xml2JsonFilter implements Filter {
 
     private static Logger LOG = LoggerFactory.getLogger( Xml2JsonFilter.class );
 
-    private String xsltFilePath;
     private TransformerUtils transformer;
 
     public void init(FilterConfig config)
             throws ServletException {
         LOG.debug( "initializing Xml2JsonFilter" );
 
-        xsltFilePath = config.getInitParameter( "xsltFile" );
+        String xsltFilePath = config.getInitParameter( "xsltFile" );
 
         if ( xsltFilePath == null ) {
             throw new ServletException( "xsltFile parameter is required for this filter" );
         }
         try {
-            transformer = getTransformer();
+            transformer = TransformerUtils.getInstanceForXsltAsFile( xsltFilePath, "main" );
         } catch ( Exception e ) {
             LOG.error( "Error loading Xslt: " + xsltFilePath );
             throw new ServletException( e );
@@ -74,8 +73,8 @@ public class Xml2JsonFilter implements Filter {
 
     }
 
-    public TransformerUtils getTransformer() throws Exception {
-        return TransformerUtils.getInstanceForXsltAsFile( xsltFilePath, "main" );
+    TransformerUtils getTransformer() throws Exception {
+        return transformer;
     }
 
     @Override

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -31,19 +31,20 @@ public class Xml2JsonFilter implements Filter {
 
     private static Logger LOG = LoggerFactory.getLogger( Xml2JsonFilter.class );
 
-    TransformerUtils transformer;
+    private String xsltFilePath;
+    private TransformerUtils transformer;
 
     public void init(FilterConfig config)
             throws ServletException {
         LOG.debug( "initializing Xml2JsonFilter" );
 
-        String xsltFilePath = config.getInitParameter( "xsltFile" );
+        xsltFilePath = config.getInitParameter( "xsltFile" );
 
         if ( xsltFilePath == null ) {
             throw new ServletException( "xsltFile parameter is required for this filter" );
         }
         try {
-            transformer = TransformerUtils.getInstanceForXsltAsFile( xsltFilePath, "main" );
+            transformer = getTransformer();
         } catch ( Exception e ) {
             LOG.error( "Error loading Xslt: " + xsltFilePath );
             throw new ServletException( e );
@@ -71,6 +72,10 @@ public class Xml2JsonFilter implements Filter {
             chain.doFilter( servletRequest, servletResponse );
         }
 
+    }
+
+    public TransformerUtils getTransformer() throws Exception {
+        return TransformerUtils.getInstanceForXsltAsFile( xsltFilePath, "main" );
     }
 
     @Override

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -29,13 +29,11 @@ public class Xml2JsonFilter implements Filter {
     public static final String JSON_MEDIA_TYPE = "application/json";
     public static final String CONTENT_TYPE_HEADER = "content-type";
 
-
-
     private static Logger LOG = LoggerFactory.getLogger( Xml2JsonFilter.class );
 
-    private TransformerUtils transformer;
+    TransformerUtils transformer;
 
-    public void  init(FilterConfig config)
+    public void init(FilterConfig config)
             throws ServletException {
         LOG.debug( "initializing Xml2JsonFilter" );
 
@@ -52,7 +50,7 @@ public class Xml2JsonFilter implements Filter {
         }
     }
 
-    public void  doFilter(ServletRequest servletRequest,
+    public void doFilter(ServletRequest servletRequest,
                           ServletResponse servletResponse,
                           final FilterChain chain)
             throws java.io.IOException, ServletException {

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonNoStreamFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonNoStreamFilter.java
@@ -25,8 +25,8 @@ import java.util.Collections;
  * It requires a Filter input parameter called 'xsltFile' which is the full path to the XSLT file to perform the
  * transformation.
  */
-public class Xml2JsonExtendedFilter extends Xml2JsonFilter {
-    private static Logger LOG = LoggerFactory.getLogger(Xml2JsonExtendedFilter.class);
+public class Xml2JsonNoStreamFilter extends Xml2JsonFilter {
+    private static Logger LOG = LoggerFactory.getLogger(Xml2JsonNoStreamFilter.class);
 
     @Override
     public void doFilter(ServletRequest servletRequest,
@@ -34,7 +34,7 @@ public class Xml2JsonExtendedFilter extends Xml2JsonFilter {
                          final FilterChain chain)
             throws java.io.IOException, ServletException {
 
-        LOG.debug( "Xml2JsonExtendedFilter doFilter()" );
+        LOG.debug( "Xml2JsonNoStreamFilter doFilter()" );
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
         HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
 
@@ -57,6 +57,7 @@ public class Xml2JsonExtendedFilter extends Xml2JsonFilter {
                     OutputStream outputStream = new ByteArrayOutputStream();
 
                     // transform response content with the xml2json xslt
+                    TransformerUtils transformer = super.getTransformer();
                     transformer.doTransform(Collections.EMPTY_MAP,
                             new StreamSource(new StringReader(originalResponseContent)),
                             new StreamResult(outputStream));
@@ -65,8 +66,8 @@ public class Xml2JsonExtendedFilter extends Xml2JsonFilter {
                     String jsonResponseContent = outputStream.toString();
                     setResponseContent(httpServletRequest, httpServletResponse, jsonResponseContent);
                 }
-                catch (Exception e) {
-                    LOG.error("Error transforming xml: " + e.getMessage());
+                catch(Exception e) {
+                    throw new ServletException(e);
                 }
                 finally {
                     httpServletResponse.getWriter().close();

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonNoStreamFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonNoStreamFilter.java
@@ -62,7 +62,7 @@ public class Xml2JsonNoStreamFilter extends Xml2JsonFilter {
                             new StreamSource(new StringReader(originalResponseContent)),
                             new StreamResult(outputStream));
 
-                    // set JsonResponse with the transformed json content to swizzle the header
+                    // set response with the transformed json content
                     String jsonResponseContent = outputStream.toString();
                     setResponseContent(httpServletRequest, httpServletResponse, jsonResponseContent);
                 }
@@ -81,15 +81,16 @@ public class Xml2JsonNoStreamFilter extends Xml2JsonFilter {
 
     private void setResponseContent(HttpServletRequest request, HttpServletResponse response, String content)
             throws IOException {
-        JsonResponseBodyWrapper jsonBodyWrapper = new JsonResponseBodyWrapper( response );
-        jsonBodyWrapper.setContentLength(content.length());
+
+        response.setContentLength(content.length());
         String acceptHeader = request.getHeader("Accept");
         if (acceptHeader != null && acceptHeader.startsWith(RAX_SVC_JSON_MEDIA_TYPE)) {
-            jsonBodyWrapper.setContentType(RAX_SVC_JSON_MEDIA_TYPE);
+            response.setContentType(RAX_SVC_JSON_MEDIA_TYPE);
         }
         else {
-            jsonBodyWrapper.setContentType(JSON_MEDIA_TYPE);
+            response.setContentType(JSON_MEDIA_TYPE);
         }
-        jsonBodyWrapper.getWriter().write(content);
+        response.getWriter().write(content);
     }
+
 }

--- a/filters/json-filter/src/test/groovy/com/rackspace/feeds/filter/Xml2JsonNoStreamFilterTest.groovy
+++ b/filters/json-filter/src/test/groovy/com/rackspace/feeds/filter/Xml2JsonNoStreamFilterTest.groovy
@@ -1,0 +1,75 @@
+package com.rackspace.feeds.filter
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest
+
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
+class Xml2JsonNoStreamFilterTest extends Specification {
+
+    @Unroll
+    def "Should say json is preferred for #method request with #acceptHeader" (String method, String acceptHeader) {
+        when:
+        HttpServletRequest request = mock(HttpServletRequest)
+        when(request.getHeader("Accept")).thenReturn(acceptHeader)
+        when(request.getMethod()).thenReturn(method)
+
+        Xml2JsonNoStreamFilter jsonFilter = new Xml2JsonNoStreamFilter()
+
+        then:
+        assert(jsonFilter.jsonPreferred(request))
+
+        where:
+        [method, acceptHeader] << [
+                ['GET', 'application/vnd.rackspace.atom+json'],
+                ['GET', 'application/vnd.rackspace.atomsvc+json'],
+                ['GET', 'application/vnd.rackspace.atom+json,application/json'],
+                ['GET', 'application/vnd.rackspace.atomsvc+json,application/json'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atom+json'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atomsvc+json'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.7, text/html'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atomsvc+json;q=0.7, text/html'],
+                ['POST', 'application/vnd.rackspace.atom+json'],
+                ['POST', 'application/vnd.rackspace.atomsvc+json'],
+                ['POST', 'application/vnd.rackspace.atom+json,application/json'],
+                ['POST', 'application/vnd.rackspace.atomsvc+json,application/json'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atom+json'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atomsvc+json'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.7, text/html'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atomsvc+json;q=0.7, text/html'],
+        ]
+    }
+
+    @Unroll
+    def "Should NOT say json is preferred for #method request with #acceptHeader" (String method, String acceptHeader) {
+        when:
+        HttpServletRequest request = mock(HttpServletRequest)
+        when(request.getHeader("Accept")).thenReturn(acceptHeader)
+        when(request.getMethod()).thenReturn(method)
+
+        Xml2JsonNoStreamFilter jsonFilter = new Xml2JsonNoStreamFilter()
+
+        then:
+        assert(!jsonFilter.jsonPreferred(request))
+
+        where:
+        [method, acceptHeader] << [
+                ['GET', 'application/json'],
+                ['GET', 'application/vnd.rackspace.atom+json;q=0.1,application/json;q=0.5'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.3'],
+                ['GET', 'application/json;q=0.5, text/html'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.8, application/atom+xml'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atom+xml;q=0.8, application/atom+xml'],
+                ['GET', 'application/json;q=0.5, application/vnd.rackspace.atomsvc+xml;q=0.8, application/atom+xml'],
+
+                ['POST', 'application/json'],
+                ['POST', 'application/vnd.rackspace.atom+json;q=0.1,application/json;q=0.5'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.3'],
+                ['POST', 'application/json;q=0.5, text/html'],
+                ['POST', 'application/json;q=0.5, application/vnd.rackspace.atom+json;q=0.8, application/atom+xml'],
+        ]
+    }
+}


### PR DESCRIPTION
- add class Xml2JsonExtendedFilter to support the json transformation in feedscatalog.
- the class make the xml2json transformation without async and explicitly set the content-length of the response

This pull request needs to be executed to support the changes in cloudfeeds-catalog for task CF-478 and story CF-303 (add json format for feeds catalog and move the resolve host filter of the catalog out of repose filter into the feedscatalog WAR as a servlet filter).

See PR 11 in cloudfeeds-catalog for dependencies:  https://github.com/rackerlabs/cloudfeeds-catalog/pull/11 