### PR TITLE
CF-303: add a flag to control whether or not we should trigger the filter on application/json

### DIFF
--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -60,10 +60,7 @@ public class Xml2JsonFilter implements Filter {
             throw new ServletException( e );
         }
 
-        String filterOnJsonStr = config.getInitParameter("filterOnGenericJsonMediaType");
-        if ( StringUtils.isNotBlank(filterOnJsonStr) ) {
-            filterOnGenericJsonMediaType = Boolean.parseBoolean(filterOnJsonStr);
-        }
+        filterOnGenericJsonMediaType = Boolean.parseBoolean(config.getInitParameter("filterOnGenericJsonMediaType"));
     }
 
     public void doFilter(ServletRequest servletRequest,

--- a/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
+++ b/filters/json-filter/src/main/java/com/rackspace/feeds/filter/Xml2JsonFilter.java
@@ -33,12 +33,23 @@ public class Xml2JsonFilter implements Filter {
 
     private TransformerUtils transformer;
 
+    /**
+     * This flag controls whether or not this Xml2Json filter is supposed to trigger
+     * when the Accept: header has the generic application/json media type.
+     *
+     * For the case of Cloud Feeds, we do not want *yet* to have this filter trigger
+     * on application/json.
+     *
+     * For the case of Cloud Feeds Catalog, we do want to have this filter trigger
+     * on application/json.
+     */
+    private boolean filterOnGenericJsonMediaType = false;
+
     public void init(FilterConfig config)
             throws ServletException {
         LOG.debug( "initializing Xml2JsonFilter" );
 
         String xsltFilePath = config.getInitParameter( "xsltFile" );
-
         if ( xsltFilePath == null ) {
             throw new ServletException( "xsltFile parameter is required for this filter" );
         }
@@ -47,6 +58,11 @@ public class Xml2JsonFilter implements Filter {
         } catch ( Exception e ) {
             LOG.error( "Error loading Xslt: " + xsltFilePath );
             throw new ServletException( e );
+        }
+
+        String filterOnJsonStr = config.getInitParameter("filterOnGenericJsonMediaType");
+        if ( StringUtils.isNotBlank(filterOnJsonStr) ) {
+            filterOnGenericJsonMediaType = Boolean.parseBoolean(filterOnJsonStr);
         }
     }
 
@@ -75,6 +91,14 @@ public class Xml2JsonFilter implements Filter {
 
     TransformerUtils getTransformer() throws Exception {
         return transformer;
+    }
+
+    protected boolean isFilterOnGenericJsonMediaType() {
+        return filterOnGenericJsonMediaType;
+    }
+
+    protected void setFilterOnGenericJsonMediaType(boolean flag) {
+        filterOnGenericJsonMediaType = flag;
     }
 
     @Override
@@ -134,6 +158,8 @@ public class Xml2JsonFilter implements Filter {
                 if ( acceptHeader.equals(ATOM_XML_MEDIA_TYPE) )  {
                     return false;
                 } else if ( acceptHeader.equals(RAX_JSON_MEDIA_TYPE) || acceptHeader.equals(RAX_SVC_JSON_MEDIA_TYPE) ) {
+                    return true;
+                } else if ( filterOnGenericJsonMediaType && acceptHeader.contains(JSON_MEDIA_TYPE) ) {
                     return true;
                 } else if ( acceptHeader.contains("json") ) {
                     // If it's json anything but it's not our vnd.rax.atom+json,


### PR DESCRIPTION
Add a new configuration flag for the filter (done in web.xml) to control whether or not the filter is to trigger Xml2Json translation on Accept header "application/json".

By default, if the flag is not specified, the behavior is to *not* trigger the translation. Cloud Feeds needs it this way.

For Cloud Feeds Catalog, we do want to trigger the translation. So the Cloud Feeds Catalog will have the flag set to true.