### PR TITLE
CF-702: update SaxonHE that works with JDK 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Some of the customizations are:
   on tenanted requests
 
 **How to build**
+To build this component, we require JDK 1.8
 ```
 mvn clean install
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>9.4.0.6</version>
+                <version>9.5.1-8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Saxon-HE version 9.4.0.x does not work with JDK 1.8. I got this error at run time:
```
Caused by: java.lang.RuntimeException: XPathFactory#newInstance() failed to create an XPathFactory for the default object model: http://java.sun.com/jaxp/xpath/dom with the XPathFactoryConfigurationException: javax.xml.xpath.XPathFactoryConfigurationException: java.util.ServiceConfigurationError: javax.xml.xpath.XPathFactory: jar:file:/Users/shin4590/.m2/repository/net/sf/saxon/Saxon-HE/9.4.0.7/Saxon-HE-9.4.0.7.jar!/META-INF/services/javax.xml.xpath.XPathFactory:2: Illegal configuration-file syntax
```
I also tried the latest Saxon-HE 9.6.0.x. It did not work. The error was:
```
should transform xml using xslt & initial template(com.rackspace.feeds.filter.TransformUtilsTest)  Time elapsed: 0.01 sec  <<< ERROR!
java.lang.ClassCastException: net.sf.saxon.jaxp.TransformerImpl cannot be cast to net.sf.saxon.Controller
        at com.rackspace.feeds.filter.XSLTTransformerPooledObjectFactory.create(XSLTTransformerPooledObjectFactory.java:48)
        at org.apache.commons.pool2.BasePooledObjectFactory.makeObject(BasePooledObjectFactory.java:60)
        at org.apache.commons.pool2.impl.GenericObjectPool.create(GenericObjectPool.java:836)
        at org.apache.commons.pool2.impl.GenericObjectPool.addObject(GenericObjectPool.java:920)
        at com.rackspace.feeds.filter.TransformerUtils.<init>(TransformerUtils.java:112)
        at com.rackspace.feeds.filter.TransformerUtils.getInstanceForXsltAsResource(TransformerUtils.java:79)
        at com.rackspace.feeds.filter.TransformUtilsTest.should transform xml using xslt & initial template(TransformUtilsTest.groovy:91)
``` 
Latest version of 9.5.1-x seems to do the trick.